### PR TITLE
fix: model create methods return scalar id instead of array

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -100,6 +100,8 @@ ignore:
   - vulnerability: CVE-2025-69420 # libcrypto3 libssl3
   - vulnerability: GHSA-34x7-hfp2-rc4v # tar
   - vulnerability: GHSA-p5wg-g6qr-c7cg # eslint
+  - vulnerability: GHSA-37qj-frw5-hhjh # fast-xml-parser
+  - vulnerability: CVE-2025-69421 # libcrypto3 libssl3
 
 # Set output format defaults
 output:

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -8,6 +8,8 @@
     "GHSA-6rw7-vpxm-498p",
     "GHSA-fjxv-7rqg-78g4",
     "GHSA-xxjr-mmjv-4gpg",
-    "GHSA-p5wg-g6qr-c7cg"
+    "GHSA-p5wg-g6qr-c7cg",
+    "GHSA-37qj-frw5-hhjh",
+    "GHSA-7h2j-956f-4vf2"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "jsonwebtoken": "^9.0.3",
         "knex": "^3.1.0",
         "moment": "^2.30.1",
-        "mysql2": "^3.16.2",
+        "mysql2": "^3.16.3",
         "node-forge": "^1.3.3",
         "node-vault": "^0.10.9",
         "oas3-tools": "^2.2.3",
@@ -49,8 +49,8 @@
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
-        "@commitlint/cli": "^20.4.0",
-        "@commitlint/config-conventional": "^20.4.0",
+        "@commitlint/cli": "^20.4.1",
+        "@commitlint/config-conventional": "^20.4.1",
         "@types/jest": "30.0.0",
         "audit-ci": "^7.1.0",
         "axios-mock-adapter": "2.1.0",
@@ -84,6 +84,28 @@
         "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -612,14 +634,14 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.0.tgz",
-      "integrity": "sha512-2lqrFrYNxjKxgMqeYiO3zNM14XN9v72/5xIJyvdLw7sHEGlfg6sweW01PGNWiqZa6/AuZwsb0uzkgWJy6F4N2w==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.1.tgz",
+      "integrity": "sha512-uuFKKpc7OtQM+6SRqT+a4kV818o1pS+uvv/gsRhyX7g4x495jg+Q7P0+O9VNGyLXBYP0syksS7gMRDJKcekr6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/format": "^20.4.0",
-        "@commitlint/lint": "^20.4.0",
+        "@commitlint/lint": "^20.4.1",
         "@commitlint/load": "^20.4.0",
         "@commitlint/read": "^20.4.0",
         "@commitlint/types": "^20.4.0",
@@ -634,9 +656,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.0.tgz",
-      "integrity": "sha512-nolhFe2YKIix0D4+tPXAWnnIc9WB5fOCgmm4h2EcRyEShC64oH/DpM9n++85NRdItvIhKb+Szsaeuug7KcEeIA==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.1.tgz",
+      "integrity": "sha512-0YUvIeBtpi86XriqrR+TCULVFiyYTIOEPjK7tTRMxjcBm1qlzb+kz7IF2WxL6Fq5DaundG8VO37BNgMkMTBwqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -662,14 +684,18 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.0.tgz",
-      "integrity": "sha512-F3qwnanJUisFWwh44GYYmMOxfgJL1FKV73FCB5zxo8pw1CHkxXadGfDfzNkN8B3iqgSGusDN2+oDH6upBmLszA==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.1.tgz",
+      "integrity": "sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/types": "^20.4.0",
-        "kasi": "^2.0.1"
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
       },
       "engines": {
         "node": ">=v18"
@@ -700,9 +726,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.0.tgz",
-      "integrity": "sha512-E8AHpedEfuf+lZatFvFiJXA4TtZgBZ10+A7HzFudaEmTPPE5o6MGswxbxUIGAciaHAFj/oTTmyFc6A5tcvxE3Q==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.1.tgz",
+      "integrity": "sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -714,15 +740,15 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.0.tgz",
-      "integrity": "sha512-W90YCbm5h3Yg+btF5/X+cxsY6vd/H3tsFt6U7WBmDQSkKV8NmitYg89zeoSQyYEiQCwAsH0dcA+99aQtLZiSnw==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.1.tgz",
+      "integrity": "sha512-g94LrGl/c6UhuhDQqNqU232aslLEN2vzc7MPfQTHzwzM4GHNnEAwVWWnh0zX8S5YXecuLXDwbCsoGwmpAgPWKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^20.4.0",
-        "@commitlint/parse": "^20.4.0",
-        "@commitlint/rules": "^20.4.0",
+        "@commitlint/is-ignored": "^20.4.1",
+        "@commitlint/parse": "^20.4.1",
+        "@commitlint/rules": "^20.4.1",
         "@commitlint/types": "^20.4.0"
       },
       "engines": {
@@ -774,9 +800,9 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.0.tgz",
-      "integrity": "sha512-NcRkqo/QUnuc1RgxRCIKTqobKzF0BKJ8h3i1jRyeZ+SEy5rO9dPNOh4BqrFsSznb5mnwETYB7ph9tUcthNkwAQ==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.1.tgz",
+      "integrity": "sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -824,13 +850,13 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.0.tgz",
-      "integrity": "sha512-E+UoAA7WA4xrre9lDyX2vL4Df26I+vqMN4D8JoW/L2xE/VRDvn533/ibhgSlGYDltB9nm2S+1lti3PagEwO0ag==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.1.tgz",
+      "integrity": "sha512-WtqypKEPbQEuJwJS4aKs0OoJRBKz1HXPBC9wRtzVNH68FLhPWzxXlF09hpUXM9zdYTpm4vAdoTGkWiBgQ/vL0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.4.0",
+        "@commitlint/ensure": "^20.4.1",
         "@commitlint/message": "^20.4.0",
         "@commitlint/to-lines": "^20.0.0",
         "@commitlint/types": "^20.4.0"
@@ -13145,13 +13171,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/kasi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kasi/-/kasi-2.0.1.tgz",
-      "integrity": "sha512-8qhiHZ1BN26ig1+jQ9fWEk6dj8T1wuxs00QRJfXIANI4scto1EuPUgqj+mxHls52WBfdTNJGQ8yYw9rDpWUcgQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -13390,8 +13409,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -13468,6 +13486,13 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13487,6 +13512,20 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -13498,6 +13537,13 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.zipobject": {
@@ -14039,9 +14085,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.2.tgz",
-      "integrity": "sha512-JsqBpYNy7pH20lGfPuSyRSIcCxSeAIwxWADpV64nP9KeyN3ZKpHZgjKXuBKsh7dH6FbOvf1bOgoVKjSUPXRMTw==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.3.tgz",
+      "integrity": "sha512-+3XhQEt4FEFuvGV0JjIDj4eP2OT/oIj/54dYvqhblnSzlfcxVOuj+cd15Xz6hsG4HU1a+A5+BA9gm0618C4z7A==",
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "jsonwebtoken": "^9.0.3",
     "knex": "^3.1.0",
     "moment": "^2.30.1",
-    "mysql2": "^3.16.2",
+    "mysql2": "^3.16.3",
     "node-forge": "^1.3.3",
     "node-vault": "^0.10.9",
     "oas3-tools": "^2.2.3",
@@ -131,8 +131,8 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@commitlint/cli": "^20.4.0",
-    "@commitlint/config-conventional": "^20.4.0",
+    "@commitlint/cli": "^20.4.1",
+    "@commitlint/config-conventional": "^20.4.1",
     "@types/jest": "30.0.0",
     "audit-ci": "^7.1.0",
     "axios-mock-adapter": "2.1.0",

--- a/src/models/DFSPEndpointItemModel.js
+++ b/src/models/DFSPEndpointItemModel.js
@@ -27,9 +27,6 @@ const runQuery = async (queryFn, operation) => db.executeWithErrorCount(queryFn,
 
 // todo: use BaseCrudModel
 exports.findById = async (id) => {
-  if (Array.isArray(id) && id.length === 1) {
-    id = id[0];
-  }
   const rows = await runQuery((knex) => knex.table(ENDPOINT_ITEMS_TABLE).where('id', id).select());
   if (rows.length === 0) {
     throw new NotFoundError('Item with id: ' + id);
@@ -68,15 +65,16 @@ exports.findObjectAll = async (dfspId) => {
 };
 
 exports.create = async (values) => {
-  const id = await DFSPModel.findIdByDfspId(values.dfspId);
+  const dfspId = await DFSPModel.findIdByDfspId(values.dfspId);
   const record = {
     state: values.state,
     type: values.type,
     value: values.value,
-    dfsp_id: id,
+    dfsp_id: dfspId,
     direction: values.direction,
   };
-  return runQuery((knex) => knex.table(ENDPOINT_ITEMS_TABLE).insert(record), 'createDFSPEndpointItem');
+  const [id] = await runQuery((knex) => knex.table(ENDPOINT_ITEMS_TABLE).insert(record), 'createDFSPEndpointItem');
+  return id;
 };
 
 exports.delete = async (id) => {

--- a/src/models/DFSPEndpointModel.js
+++ b/src/models/DFSPEndpointModel.js
@@ -126,7 +126,7 @@ exports.findLastestByDirection = async (dfspId, direction) => {
 };
 
 /**
- * Creates an endpoint, and parses the JSON in value, returning an Object.
+ * Creates an endpoint, and returns the inserted id.
  */
 exports.create = async (dfspId, state, direction, value) => {
   const validatedDfspId = await DFSPModel.findIdByDfspId(dfspId);
@@ -136,7 +136,8 @@ exports.create = async (dfspId, state, direction, value) => {
     dfsp_id: validatedDfspId,
     direction,
   };
-  return runQuery(knex => knex.table(ENDPOINT_TABLE).insert(record), 'createEndpoint');
+  const [id] = await runQuery(knex => knex.table(ENDPOINT_TABLE).insert(record), 'createEndpoint');
+  return id;
 };
 
 /**

--- a/src/models/HubEndpointItemModel.js
+++ b/src/models/HubEndpointItemModel.js
@@ -66,7 +66,8 @@ exports.create = async (values) => {
     value: values.value,
     direction: values.direction,
   };
-  return runQuery((knex) => knex.table(ENDPOINT_ITEMS_TABLE).insert(record), 'createHubEndpointItem');
+  const [id] = await runQuery((knex) => knex.table(ENDPOINT_ITEMS_TABLE).insert(record), 'createHubEndpointItem');
+  return id;
 };
 
 exports.delete = async (id) => {

--- a/test/int/models/DFSPEndpointItemModel.test.js
+++ b/test/int/models/DFSPEndpointItemModel.test.js
@@ -32,19 +32,6 @@ describe('DFSPEndpointItemModel', () => {
       expect(result).toEqual(mockRow);
     });
 
-    it('should return the item when found with id in array', async () => {
-      const id = [1];
-      const mockRow = { id: 1, value: 'test' };
-      knex.table.mockReturnValue({
-        where: jest.fn().mockReturnValue({
-          select: jest.fn().mockResolvedValue([mockRow])
-        })
-      });
-
-      const result = await DFSPEndpointItemModel.findById(id);
-      expect(result).toEqual(mockRow);
-    });
-
     it('should throw NotFoundError when item is not found', async () => {
       const id = 1;
       knex.table.mockReturnValue({
@@ -123,7 +110,7 @@ describe('DFSPEndpointItemModel', () => {
       });
 
       const result = await DFSPEndpointItemModel.create(values);
-      expect(result).toEqual([1]);
+      expect(result).toEqual(1);
     });
   });
 

--- a/test/int/models/HubEndpointItemModel.test.js
+++ b/test/int/models/HubEndpointItemModel.test.js
@@ -77,7 +77,7 @@ describe('HubEndpointItemModel', () => {
 
             const result = await HubEndpointItemModel.create(values);
             expect(insertStub.called).toBe(true);
-            expect(result).toEqual([1]);
+            expect(result).toEqual(1);
         });
 
         it('should throw an error if insert fails', async () => {


### PR DESCRIPTION
Knex insert returns [insertId] array, causing findById to fail.
Destructure to return scalar id. Remove array workaround in findById.