### PR TITLE
feat: implement audit log storage and API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/hapi": "21.4.9",
-        "@keycloak/keycloak-admin-client": "^26.6.2",
+        "@keycloak/keycloak-admin-client": "^26.6.3",
         "@kubernetes/client-node": "^1.4.0",
         "@mojaloop/central-services-logger": "11.10.4",
         "@mojaloop/central-services-metrics": "12.8.5",
@@ -18,7 +18,7 @@
         "@ory/keto-client": "^26.2.0",
         "async-exit-hook": "^2.0.1",
         "async-retry": "^1.3.3",
-        "axios": "1.16.1",
+        "axios": "1.17.0",
         "body-parser": "^2.2.2",
         "connect": "^3.7.0",
         "convict": "6.2.5",
@@ -31,7 +31,7 @@
         "express-winston": "^4.2.0",
         "form-data": "^4.0.5",
         "joi": "^18.2.1",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "jsonwebtoken": "^9.0.3",
         "knex": "^3.2.10",
         "moment": "^2.30.1",
@@ -49,8 +49,8 @@
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
-        "@commitlint/cli": "^21.0.1",
-        "@commitlint/config-conventional": "^21.0.1",
+        "@commitlint/cli": "^21.0.2",
+        "@commitlint/config-conventional": "^21.0.2",
         "@ory/keto-namespace-types": "^0.13.0-alpha.0",
         "@types/jest": "30.0.0",
         "audit-ci": "^7.1.0",
@@ -63,7 +63,7 @@
         "husky": "^9.1.7",
         "jest": "^30.0.2",
         "jest-extended": "^7.0.0",
-        "npm-check-updates": "^22.2.1",
+        "npm-check-updates": "^22.2.2",
         "nyc": "^18.0.0",
         "sinon": "^22.0.0",
         "snazzy": "^9.0.0",
@@ -72,7 +72,7 @@
         "standardx": "^7.0.0",
         "supertest": "^7.2.2",
         "tap-xunit": "^2.4.1",
-        "tmp": "^0.2.6"
+        "tmp": "^0.2.7"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -635,16 +635,16 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.1.tgz",
-      "integrity": "sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.2.tgz",
+      "integrity": "sha512-YMmfLbqBg+ZRvvmPhc+cilSQFrh/AgzVgCT1U/OifmUZEwPbvCtA8rN//YNaF9d5eoZphxVMGYtmwA2QgQORgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/format": "^21.0.1",
-        "@commitlint/lint": "^21.0.1",
-        "@commitlint/load": "^21.0.1",
-        "@commitlint/read": "^21.0.1",
+        "@commitlint/lint": "^21.0.2",
+        "@commitlint/load": "^21.0.2",
+        "@commitlint/read": "^21.0.2",
         "@commitlint/types": "^21.0.1",
         "tinyexec": "^1.0.0",
         "yargs": "^18.0.0"
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.1.tgz",
-      "integrity": "sha512-gRorrkfWOh/+V5X8GYWWbQvrzPczopGMS4CCNrQdHkK4xWElv82BDvIsDhJZWTlI7TazOlYea6VATufCsFs+sw==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.2.tgz",
+      "integrity": "sha512-P/ZRhryQmkj0Z0dY9FOoRwe3xkwJyyAdtXwt01NT2kuZttcG2CNYp1q5Ci3u+nDT2jcbJRw2kt13Czl1qKNPfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.1.tgz",
-      "integrity": "sha512-iNDP8SFdw8JEkM0CHZ2XFnhTN4Zg5jKUY2d8kBOSFrI2aA+3YJI7fcqVpfgbpJ9xtxFVYpi+DBATU5AvhoTq8g==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.2.tgz",
+      "integrity": "sha512-H5z4t8PC9tUsmZ/o+EptM3Nq8sTFtskAShdcqxCoyzklW5eaVT5xbrDAET2uypzir9Vsj4ZZmBtyKjYe2XqgeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -737,15 +737,15 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.1.tgz",
-      "integrity": "sha512-gF+iYtUw1gBG3HUH9z3VxwUjGg2R2G5j+nmvPs8aIeYkiB7TtneBu3wO85I0bUl93bYNsvsCNI9Nte2fmDUMww==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.2.tgz",
+      "integrity": "sha512-PnUmLYGeGLfW8oVatR9KpNxSHYAnJOEWlMZzfdeFOUq6WUrFx1fGQaWCWJqMoIll/xPM+GdfJV+tKHZVHhl0Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^21.0.1",
-        "@commitlint/parse": "^21.0.1",
-        "@commitlint/rules": "^21.0.1",
+        "@commitlint/is-ignored": "^21.0.2",
+        "@commitlint/parse": "^21.0.2",
+        "@commitlint/rules": "^21.0.2",
         "@commitlint/types": "^21.0.1"
       },
       "engines": {
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.1.tgz",
-      "integrity": "sha512-Btg1q1mKmiihN4W3x0EsPDrJMOQfMa9NIqlzlJyXAfxvsOGdGXOW5p3R3RcSxDCaY7JabY9flIl+Om1af3PSrw==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.2.tgz",
+      "integrity": "sha512-lwUE70hN0/qE/ZRROhbaX65ly/FF12DrqfReLCESo37M0OQCFAf2jRS+2tSCSORq+bm4Kdju7qNDj46uc1QzTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.1.tgz",
-      "integrity": "sha512-R3dVQeJQ0B6yqrZEjkUHD4r7UJYLV9Lvk2xs3PTOmtWk2G3mI6Xgc+YdRxL1PwcDfBiUjv2SkIkW4AUc976w1w==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.2.tgz",
+      "integrity": "sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.1.tgz",
-      "integrity": "sha512-oh/nCSOqdoeQNA1tO8aAmxkq5EBo8/NzcFQRvv66AWc9HpED28sL2iSicCKU6hPintWuscL6BJEWi77Wq1LPMQ==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.2.tgz",
+      "integrity": "sha512-QVZJhGHTm+oiuWyEKOCTQ0ZM3mfJ0eGWFeHuj7WzSKEth+UukcCHac9GD8pgdFlg/qGkFWOtyaNd1T8REgagaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -799,13 +799,13 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.1.tgz",
-      "integrity": "sha512-pMEu4lbpC8W0ZgKJj2U6WaobXIZWdFlULpIEewYhkPXx+WZcnoO53YrVPc7QErQuNolq2Me8dP58Wu7YAVXVOA==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.2.tgz",
+      "integrity": "sha512-BtsrnLVycSSKf4Q0gMch4giCj5NNlmcbhc8ra5vONgGtP2IjRDo33bEFtr5Pm+2N+5fXGWb2MksWPrspPfdhdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^21.0.1",
+        "@commitlint/top-level": "^21.0.2",
         "@commitlint/types": "^21.0.1",
         "git-raw-commits": "^5.0.0",
         "tinyexec": "^1.0.0"
@@ -832,14 +832,14 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.1.tgz",
-      "integrity": "sha512-VMooYpz4nJg7xlaUso6CCOWEz8D/ChkvsvZUMARcoJ1ZpfKPyFCGrHNha2tbsETNAb6ErgiRuCr2DvghrvPDYQ==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.2.tgz",
+      "integrity": "sha512-k6tQ69Td7t2qUSIbik8D3TL1q3ZJpkEbV+yLogDzCRAdOxJm4ndhtBNREsLA1/puRfWvzS9eioF2w43WT+hHgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/ensure": "^21.0.1",
-        "@commitlint/message": "^21.0.1",
+        "@commitlint/message": "^21.0.2",
         "@commitlint/to-lines": "^21.0.1",
         "@commitlint/types": "^21.0.1"
       },
@@ -858,9 +858,9 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.1.tgz",
-      "integrity": "sha512-4esUYqzY7K0FCgcJ/1xWEZekV7Ch4yZT1+xjEb7KzqbJ05XEkxHVsTfC8ADKNNtlCE2pj98KEbPGZWw9WwEnVw==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.2.tgz",
+      "integrity": "sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2109,9 +2109,9 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.6.2.tgz",
-      "integrity": "sha512-CEqQ/fzJPkWOTM0LaUeH5KAKlCQGkqlydhpnxFM9Vx1rLyjr9AIqrENPNzt0owYDPIqrl6OYaFZJBAoH8woDpA==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-26.6.3.tgz",
+      "integrity": "sha512-hHSdEl9Hxww7w1Q+SbMPshhHxjvZZsNEfsL+7PXGxi0fYPggSQUyd/PC1ko1/UX7gNyDmDI89sOYSBoFQ/bcaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@microsoft/kiota-abstractions": "^1.0.0-preview.86",
@@ -2370,6 +2370,18 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@mojaloop/central-services-shared/node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/@mojaloop/central-services-shared/node_modules/lodash": {
       "version": "4.18.1",
@@ -3977,9 +3989,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -7145,9 +7157,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
-      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -11835,9 +11847,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13226,9 +13248,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "22.2.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.1.tgz",
-      "integrity": "sha512-mGdIJfhtg+q0BzhbOpbOL73zhMZlgBQMG4wnBwPMMD5k96028UCuV0753YeSYk9odoh7HWK6/cY69bWxT7o+yg==",
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.2.tgz",
+      "integrity": "sha512-dgDPmR9FfONMrHdMKsPoYzb2NgR+NxlLGBi3nL/3yN3aFr8IKLyQJMBEMj4pKM5yuv9esV4nL5TX0TY2veliNw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -18438,9 +18460,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18448,9 +18470,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -87,13 +87,13 @@
     "yargs-parser": "21.1.1",
     "tar-fs": ">=3.1.1",
     "tough-cookie": ">=4.1.3",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "glob": ">=11.1.0",
     "uuid": "11.1.1"
   },
   "dependencies": {
     "@hapi/hapi": "21.4.9",
-    "@keycloak/keycloak-admin-client": "^26.6.2",
+    "@keycloak/keycloak-admin-client": "^26.6.3",
     "@kubernetes/client-node": "^1.4.0",
     "@mojaloop/central-services-logger": "11.10.4",
     "@mojaloop/central-services-metrics": "12.8.5",
@@ -101,7 +101,7 @@
     "@ory/keto-client": "^26.2.0",
     "async-exit-hook": "^2.0.1",
     "async-retry": "^1.3.3",
-    "axios": "1.16.1",
+    "axios": "1.17.0",
     "body-parser": "^2.2.2",
     "connect": "^3.7.0",
     "convict": "6.2.5",
@@ -114,7 +114,7 @@
     "express-winston": "^4.2.0",
     "form-data": "^4.0.5",
     "joi": "^18.2.1",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "jsonwebtoken": "^9.0.3",
     "knex": "^3.2.10",
     "moment": "^2.30.1",
@@ -132,8 +132,8 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@commitlint/cli": "^21.0.1",
-    "@commitlint/config-conventional": "^21.0.1",
+    "@commitlint/cli": "^21.0.2",
+    "@commitlint/config-conventional": "^21.0.2",
     "@ory/keto-namespace-types": "^0.13.0-alpha.0",
     "@types/jest": "30.0.0",
     "audit-ci": "^7.1.0",
@@ -146,7 +146,7 @@
     "husky": "^9.1.7",
     "jest": "^30.0.2",
     "jest-extended": "^7.0.0",
-    "npm-check-updates": "^22.2.1",
+    "npm-check-updates": "^22.2.3",
     "nyc": "^18.0.0",
     "sinon": "^22.0.0",
     "snazzy": "^9.0.0",
@@ -155,7 +155,7 @@
     "standardx": "^7.0.0",
     "supertest": "^7.2.2",
     "tap-xunit": "^2.4.1",
-    "tmp": "^0.2.6"
+    "tmp": "^0.2.7"
   },
   "standardx": {
     "semistandard": true

--- a/src/api/swagger.yaml
+++ b/src/api/swagger.yaml
@@ -2649,6 +2649,70 @@ paths:
       - OAuth2:
         - dfsp
       x-swagger-router-controller: CredentialsController
+  /audit-log:
+    get:
+      tags:
+      - audit-log
+      summary: Returns IAM audit log entries
+      operationId: getAuditLog
+      parameters:
+      - name: from
+        in: query
+        description: Filter entries on or after this ISO 8601 datetime
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: to
+        in: query
+        description: Filter entries on or before this ISO 8601 datetime
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: actor
+        in: query
+        description: Filter by actor (username or email)
+        required: false
+        schema:
+          type: string
+      - name: action
+        in: query
+        description: Filter by action type (CREATE, UPDATE, DELETE)
+        required: false
+        schema:
+          type: string
+          enum: [READ, CREATE, UPDATE, DELETE]
+      - name: limit
+        in: query
+        description: Maximum number of entries to return (default 100)
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 100
+      - name: offset
+        in: query
+        description: Number of entries to skip for pagination
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditLogEntry'
+      x-swagger-router-controller: AuditController
+      security:
+      - OAuth2:
+        - pta
   /monetaryzones:
     get:
       tags:
@@ -2696,6 +2760,35 @@ paths:
         - pta
 components:
   schemas:
+    AuditLogEntry:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        createdAt:
+          type: string
+          format: date-time
+        actor:
+          type: string
+          nullable: true
+        action:
+          type: string
+          enum: [READ, CREATE, UPDATE, DELETE]
+        entityType:
+          type: string
+          nullable: true
+        entityId:
+          type: string
+          nullable: true
+        beforeState:
+          type: object
+          nullable: true
+          additionalProperties: true
+        afterState:
+          type: object
+          nullable: true
+          additionalProperties: true
     LoginResponse:
       type: object
       properties:

--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -23,6 +23,7 @@ const path = require('path');
 const oas3Tools = require('oas3-tools');
 const { createWinstonLogger, logger } = require('./log/logger');
 const AuthMiddleware = require('./middleware/AuthMiddleware');
+const AuditMiddleware = require('./middleware/AuditMiddleware');
 const DfspIdValidationMiddleware = require('./middleware/DfspIdValidationMiddleware');
 const SessionConfig = require('./oauth/SessionConfig');
 const HubCAService = require('./service/HubCAService');
@@ -118,6 +119,9 @@ exports.connect = async () => {
     cors(corsUtils.getCorsOptions),
     createWinstonLogger()
   ];
+
+  // Audit middleware runs after auth so req.user is populated
+  middlewares.push(AuditMiddleware.createAuditMiddleware());
 
   // Add DFSP ID validation middleware if enabled
   if (Constants.dfspIdHeaderValidationEnabled) {

--- a/src/controllers/AuditController.js
+++ b/src/controllers/AuditController.js
@@ -1,0 +1,41 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Mojaloop Foundation for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Mojaloop Foundation
+ * decker757
+
+ --------------
+ ******/
+'use strict';
+
+const AuditService = require('../service/AuditService');
+const { logger } = require('../log/logger');
+
+exports.getAuditLog = async (req, res) => {
+  try {
+    const { from, to, actor, action, limit, offset } = req.query;
+    const entries = await AuditService.getAuditLog({ from, to, actor, action, limit, offset });
+    res.json(entries);
+  } catch (error) {
+    logger.error('getAuditLog error:', error);
+    res.status(500).json({ error: 'Failed to retrieve audit log' });
+  }
+};

--- a/src/db/migrations/20260606000001_create_audit_log_table.js
+++ b/src/db/migrations/20260606000001_create_audit_log_table.js
@@ -1,0 +1,57 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Mojaloop Foundation for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Mojaloop Foundation
+ * decker757
+
+ --------------
+ ******/
+
+const TABLE = 'audit_log';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE, (table) => {
+    table.bigIncrements('id').primary();
+    table.datetime('created_at').notNullable().defaultTo(knex.fn.now());
+    table.string('actor', 255).nullable();
+    table.string('action', 100).notNullable();
+    table.string('entity_type', 100).nullable();
+    table.string('entity_id', 255).nullable();
+    table.json('before_state').nullable();
+    table.json('after_state').nullable();
+
+    table.index(['created_at']);
+    table.index(['actor']);
+    table.index(['action']);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable(TABLE);
+};

--- a/src/middleware/AuditMiddleware.js
+++ b/src/middleware/AuditMiddleware.js
@@ -1,0 +1,101 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Mojaloop Foundation for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Mojaloop Foundation
+ * decker757
+
+ --------------
+ ******/
+
+
+'use strict';
+
+const AuditService = require('../service/AuditService');
+const { logger } = require('../log/logger');
+
+const AUDITED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+
+const METHOD_TO_ACTION = {
+  GET: 'READ',
+  POST: 'CREATE',
+  PUT: 'UPDATE',
+  PATCH: 'UPDATE',
+  DELETE: 'DELETE',
+};
+
+// Have to clarify if we want to establish the endpoints from KeycloakService
+const IAM_PATHS = new Set(['roles', 'permissions', 'members', 'membership', 'users', 'groups']);
+
+/**
+ * Extracts the entity type and ID from the request path.
+ * e.g. /api/roles/123 → { entityType: 'roles', entityId: '123' }
+ */
+function extractEntity(path) {
+  const segments = path.replace(/^\/+/, '').split('/').filter(Boolean);
+  // Skip leading 'api' segment if present
+  const start = segments[0] === 'api' ? 1 : 0;
+  const entityType = segments[start] || null;
+  const entityId = segments[start + 1] || null;
+  return { entityType, entityId };
+}
+
+exports.createAuditMiddleware = () => {
+  return async (req, res, next) => {
+    try {
+      if (!AUDITED_METHODS.has(req.method)) {
+        return next();
+      }
+
+      const firstSegment = req.path.split('/').filter(Boolean)[0];
+      if (!IAM_PATHS.has(firstSegment)) {
+        return next();
+      }
+
+      const action = METHOD_TO_ACTION[req.method];
+      const actor = req.user?.id || null;
+      const { entityType, entityId } = extractEntity(req.path);
+      const beforeState = req.body && Object.keys(req.body).length > 0 ? req.body : null;
+
+      const originalJson = res.json.bind(res);
+      res.json = function (body) {
+        res.json = originalJson;
+
+        const afterState = res.statusCode >= 200 && res.statusCode < 300 ? body : null;
+
+        AuditService.createAuditEntry({
+          actor,
+          action,
+          entityType,
+          entityId,
+          beforeState: action !== 'CREATE' ? beforeState : null,
+          afterState,
+        }).catch((err) => logger.error('Failed to write audit log entry:', err));
+
+        return originalJson(body);
+      };
+
+      next();
+    } catch (error) {
+      logger.error('Audit middleware error:', error);
+      next(error);
+    }
+  };
+};

--- a/src/models/AuditModel.js
+++ b/src/models/AuditModel.js
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *  Copyright 2019 ModusBox, Inc.                                             *
+ *                                                                            *
+ *  info@modusbox.com                                                         *
+ *                                                                            *
+ *  Licensed under the Apache License, Version 2.0 (the "License");           *
+ *  you may not use this file except in compliance with the License.          *
+ *  You may obtain a copy of the License at                                   *
+ *  http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                            *
+ *  Unless required by applicable law or agreed to in writing, software       *
+ *  distributed under the License is distributed on an "AS IS" BASIS,         *
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ *  See the License for the specific language governing permissions and       *
+ *  limitations under the License.                                            *
+ ******************************************************************************/
+
+const db = require('../db/database');
+
+const TABLE = 'audit_log';
+const runQuery = async (queryFn, operation) => db.executeWithErrorCount(queryFn, operation);
+
+exports.create = async (entry) => {
+  const row = {
+    created_at: entry.createdAt || new Date(),
+    actor: entry.actor || null,
+    action: entry.action,
+    entity_type: entry.entityType || null,
+    entity_id: entry.entityId || null,
+    before_state: entry.beforeState ? JSON.stringify(entry.beforeState) : null,
+    after_state: entry.afterState ? JSON.stringify(entry.afterState) : null,
+  };
+  const [id] = await runQuery((knex) => knex.table(TABLE).insert(row), 'createAuditEntry');
+  return { id };
+};
+
+exports.findAll = async ({ from, to, actor, action, limit = 100, offset = 0 } = {}) => {
+  const rows = await runQuery((knex) => {
+    const q = knex.table(TABLE).select().orderBy('created_at', 'desc').limit(limit).offset(offset);
+    if (from) q.where('created_at', '>=', new Date(from));
+    if (to) q.where('created_at', '<=', new Date(to));
+    if (actor) q.where('actor', actor);
+    if (action) q.where('action', action);
+    return q;
+  }, 'findAuditLog');
+
+  return rows.map((row) => ({
+    id: row.id,
+    createdAt: row.created_at,
+    actor: row.actor,
+    action: row.action,
+    entityType: row.entity_type,
+    entityId: row.entity_id,
+    beforeState: row.before_state ?? null,
+    afterState: row.after_state ?? null,
+  }));
+};

--- a/src/service/AuditService.js
+++ b/src/service/AuditService.js
@@ -1,0 +1,33 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Mojaloop Foundation for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Mojaloop Foundation
+ * decker757
+ --------------
+ ******/
+
+'use strict';
+
+const AuditModel = require('../models/AuditModel');
+
+exports.createAuditEntry = (entry) => AuditModel.create(entry);
+
+exports.getAuditLog = (filters) => AuditModel.findAll(filters);

--- a/test/int/AuditService.test.js
+++ b/test/int/AuditService.test.js
@@ -1,0 +1,114 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ **/
+
+
+const { setupTestDB, tearDownTestDB } = require('./test-database');
+const AuditService = require('../../src/service/AuditService');
+const db = require('../../src/db/database');
+
+describe('AuditService Integration Tests', () => {
+  beforeAll(async () => {
+    await setupTestDB();
+  });
+
+  afterAll(async () => {
+    await tearDownTestDB();
+  });
+
+  afterEach(async () => {
+    await db.knex.table('audit_log').del();
+  });
+
+  describe('createAuditEntry', () => {
+    it('should insert an audit entry and return an id', async () => {
+      const result = await AuditService.createAuditEntry({
+        actor: 'user-123',
+        action: 'CREATE',
+        entityType: 'roles',
+        entityId: '1',
+        beforeState: null,
+        afterState: { name: 'admin' },
+      });
+
+      expect(result).toHaveProperty('id');
+      expect(typeof result.id).toBe('number');
+    });
+  });
+
+  describe('getAuditLog', () => {
+    beforeEach(async () => {
+      await AuditService.createAuditEntry({ actor: 'user-111', action: 'CREATE', entityType: 'roles', entityId: '1', afterState: { name: 'admin' } });
+      await AuditService.createAuditEntry({ actor: 'user-222', action: 'UPDATE', entityType: 'roles', entityId: '1', beforeState: { name: 'admin' }, afterState: { name: 'superadmin' } });
+      await AuditService.createAuditEntry({ actor: 'user-111', action: 'DELETE', entityType: 'roles', entityId: '2' });
+    });
+
+    it('should return all entries when no filters are provided', async () => {
+      const entries = await AuditService.getAuditLog();
+      expect(entries.length).toBe(3);
+    });
+
+    it('should filter by actor', async () => {
+      const entries = await AuditService.getAuditLog({ actor: 'user-111' });
+      expect(entries.length).toBe(2);
+      expect(entries.every((e) => e.actor === 'user-111')).toBe(true);
+    });
+
+    it('should filter by action', async () => {
+      const entries = await AuditService.getAuditLog({ action: 'UPDATE' });
+      expect(entries.length).toBe(1);
+      expect(entries[0].action).toBe('UPDATE');
+    });
+
+    it('should filter by date range', async () => {
+      const from = new Date(Date.now() - 60000).toISOString();
+      const to = new Date(Date.now() + 60000).toISOString();
+      const entries = await AuditService.getAuditLog({ from, to });
+      expect(entries.length).toBe(3);
+    });
+
+    it('should return no entries outside the date range', async () => {
+      const from = new Date(Date.now() + 60000).toISOString();
+      const to = new Date(Date.now() + 120000).toISOString();
+      const entries = await AuditService.getAuditLog({ from, to });
+      expect(entries.length).toBe(0);
+    });
+
+    it('should respect limit and offset', async () => {
+      const entries = await AuditService.getAuditLog({ limit: 2, offset: 0 });
+      expect(entries.length).toBe(2);
+
+      const nextPage = await AuditService.getAuditLog({ limit: 2, offset: 2 });
+      expect(nextPage.length).toBe(1);
+    });
+
+    it('should return entries with correct camelCase fields', async () => {
+      const entries = await AuditService.getAuditLog({ action: 'UPDATE' });
+      const entry = entries[0];
+
+      expect(entry).toHaveProperty('id');
+      expect(entry).toHaveProperty('createdAt');
+      expect(entry).toHaveProperty('actor');
+      expect(entry).toHaveProperty('action');
+      expect(entry).toHaveProperty('entityType');
+      expect(entry).toHaveProperty('entityId');
+      expect(entry).toHaveProperty('beforeState');
+      expect(entry).toHaveProperty('afterState');
+    });
+
+    it('should parse beforeState and afterState as objects', async () => {
+      const entries = await AuditService.getAuditLog({ action: 'UPDATE' });
+      const entry = entries[0];
+
+      expect(entry.beforeState).toEqual({ name: 'admin' });
+      expect(entry.afterState).toEqual({ name: 'superadmin' });
+    });
+  });
+});

--- a/test/unit/controllers/AuditController.test.js
+++ b/test/unit/controllers/AuditController.test.js
@@ -1,0 +1,89 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Mojaloop Foundation for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Mojaloop Foundation
+
+ --------------
+ ******/
+
+'use strict';
+
+jest.mock('#src/service/AuditService', () => ({
+  getAuditLog: jest.fn()
+}));
+
+const AuditController = require('#src/controllers/AuditController');
+const AuditService = require('#src/service/AuditService');
+
+describe('AuditController', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    req = { query: {} };
+
+    res = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+  });
+
+  describe('getAuditLog', () => {
+    it('should return audit log entries on success', async () => {
+      const mockEntries = [
+        { id: 1, actor: 'user-123', action: 'CREATE', entityType: 'roles', entityId: '1' }
+      ];
+      AuditService.getAuditLog.mockResolvedValue(mockEntries);
+
+      await AuditController.getAuditLog(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(mockEntries);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should pass query filters to the service', async () => {
+      AuditService.getAuditLog.mockResolvedValue([]);
+      req.query = { from: '2026-01-01', to: '2026-12-31', actor: 'user-123', action: 'CREATE', limit: '50', offset: '10' };
+
+      await AuditController.getAuditLog(req, res);
+
+      expect(AuditService.getAuditLog).toHaveBeenCalledWith({
+        from: '2026-01-01',
+        to: '2026-12-31',
+        actor: 'user-123',
+        action: 'CREATE',
+        limit: '50',
+        offset: '10',
+      });
+    });
+
+    it('should return 500 when service throws', async () => {
+      AuditService.getAuditLog.mockRejectedValue(new Error('DB error'));
+
+      await AuditController.getAuditLog(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Failed to retrieve audit log' });
+    });
+  });
+});

--- a/test/unit/middleware/AuditMiddleware.test.js
+++ b/test/unit/middleware/AuditMiddleware.test.js
@@ -1,0 +1,225 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Mojaloop Foundation for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Mojaloop Foundation
+ * decker757
+
+ --------------
+ ******/
+
+'use strict';
+
+jest.mock('#src/service/AuditService', () => ({
+  createAuditEntry: jest.fn().mockResolvedValue({ id: 1 })
+}));
+
+const { createAuditMiddleware } = require('#src/middleware/AuditMiddleware');
+const AuditService = require('#src/service/AuditService');
+
+describe('AuditMiddleware', () => {
+  let middleware;
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    middleware = createAuditMiddleware();
+
+    req = {
+      method: 'POST',
+      path: '/roles',
+      user: { id: 'user-123' },
+      body: {}
+    };
+
+    res = {
+      statusCode: 200,
+      json: jest.fn()
+    };
+
+    next = jest.fn();
+  });
+
+  describe('method filtering', () => {
+    it('should skip non-audited methods and call next', async () => {
+      req.method = 'OPTIONS';
+      req.path = '/roles';
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(AuditService.createAuditEntry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('path filtering', () => {
+    it('should skip non-IAM paths and call next', async () => {
+      req.method = 'POST';
+      req.path = '/dfsps/DFSP1/ca';
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(AuditService.createAuditEntry).not.toHaveBeenCalled();
+    });
+
+    it.each(['roles', 'permissions', 'members', 'membership', 'users', 'groups'])(
+      'should audit IAM path /%s',
+      async (iamPath) => {
+        req.path = `/${iamPath}`;
+
+        await middleware(req, res, next);
+        res.json({ id: 1 });
+
+        expect(AuditService.createAuditEntry).toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('action mapping', () => {
+    it.each([
+      ['GET', 'READ'],
+      ['POST', 'CREATE'],
+      ['PUT', 'UPDATE'],
+      ['PATCH', 'UPDATE'],
+      ['DELETE', 'DELETE'],
+    ])('should map %s to action %s', async (method, expectedAction) => {
+      req.method = method;
+      req.path = '/roles';
+
+      await middleware(req, res, next);
+      res.json({ id: 1 });
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ action: expectedAction })
+      );
+    });
+  });
+
+  describe('actor extraction', () => {
+    it('should extract actor from req.user.id', async () => {
+      req.user = { id: 'user-abc' };
+
+      await middleware(req, res, next);
+      res.json({});
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ actor: 'user-abc' })
+      );
+    });
+
+    it('should set actor to null when req.user is not set', async () => {
+      req.user = null;
+
+      await middleware(req, res, next);
+      res.json({});
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ actor: null })
+      );
+    });
+  });
+
+  describe('entity extraction', () => {
+    it('should extract entityType and entityId from path', async () => {
+      req.path = '/roles/123';
+
+      await middleware(req, res, next);
+      res.json({});
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: 'roles', entityId: '123' })
+      );
+    });
+
+    it('should set entityId to null when path has no id segment', async () => {
+      req.path = '/roles';
+
+      await middleware(req, res, next);
+      res.json({});
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: 'roles', entityId: null })
+      );
+    });
+  });
+
+  describe('beforeState and afterState', () => {
+    it('should set beforeState to null for CREATE actions', async () => {
+      req.method = 'POST';
+      req.body = { name: 'admin' };
+
+      await middleware(req, res, next);
+      res.json({ id: 1, name: 'admin' });
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ beforeState: null })
+      );
+    });
+
+    it('should capture req.body as beforeState for UPDATE actions', async () => {
+      req.method = 'PUT';
+      req.body = { name: 'admin' };
+
+      await middleware(req, res, next);
+      res.json({ id: 1, name: 'admin' });
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ beforeState: { name: 'admin' } })
+      );
+    });
+
+    it('should capture response body as afterState on success', async () => {
+      res.statusCode = 200;
+
+      await middleware(req, res, next);
+      res.json({ id: 1 });
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ afterState: { id: 1 } })
+      );
+    });
+
+    it('should set afterState to null on error response', async () => {
+      res.statusCode = 400;
+
+      await middleware(req, res, next);
+      res.json({ error: 'Bad Request' });
+
+      expect(AuditService.createAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ afterState: null })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should call next(error) when middleware throws', async () => {
+      Object.defineProperty(req, 'method', {
+        get: () => { throw new Error('Test error'); }
+      });
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+});

--- a/test/unit/models/AuditModel.test.js
+++ b/test/unit/models/AuditModel.test.js
@@ -1,0 +1,155 @@
+/*****
+ License
+ --------------
+ Copyright © 2020-2025 Mojaloop Foundation
+ The Mojaloop files are made available by the Mojaloop Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Mojaloop Foundation for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+
+ * Mojaloop Foundation
+ * decker757
+
+ --------------
+ ******/
+
+'use strict';
+
+jest.mock('#src/db/database', () => ({
+  executeWithErrorCount: jest.fn()
+}));
+
+const AuditModel = require('#src/models/AuditModel');
+const mockDb = require('#src/db/database');
+
+describe('AuditModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should insert a row and return the id', async () => {
+      mockDb.executeWithErrorCount.mockResolvedValue([42]);
+
+      const result = await AuditModel.create({
+        actor: 'user-123',
+        action: 'CREATE',
+        entityType: 'roles',
+        entityId: '1',
+        beforeState: null,
+        afterState: { id: 1, name: 'admin' },
+      });
+
+      expect(result).toEqual({ id: 42 });
+      expect(mockDb.executeWithErrorCount).toHaveBeenCalledWith(
+        expect.any(Function),
+        'createAuditEntry'
+      );
+    });
+
+    it('should JSON.stringify beforeState and afterState', async () => {
+      let capturedRow;
+      mockDb.executeWithErrorCount.mockImplementation(async (queryFn) => {
+        const knex = {
+          table: () => ({
+            insert: (row) => { capturedRow = row; return [1]; }
+          })
+        };
+        return queryFn(knex);
+      });
+
+      await AuditModel.create({
+        actor: 'user-123',
+        action: 'UPDATE',
+        entityType: 'roles',
+        entityId: '1',
+        beforeState: { name: 'old' },
+        afterState: { name: 'new' },
+      });
+
+      expect(capturedRow.before_state).toBe(JSON.stringify({ name: 'old' }));
+      expect(capturedRow.after_state).toBe(JSON.stringify({ name: 'new' }));
+    });
+
+    it('should use current date when createdAt is not provided', async () => {
+      let capturedRow;
+      mockDb.executeWithErrorCount.mockImplementation(async (queryFn) => {
+        const knex = {
+          table: () => ({
+            insert: (row) => { capturedRow = row; return [1]; }
+          })
+        };
+        return queryFn(knex);
+      });
+      const before = new Date();
+
+      await AuditModel.create({ action: 'CREATE' });
+
+      expect(capturedRow.created_at).toBeInstanceOf(Date);
+      expect(capturedRow.created_at.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+  });
+
+  describe('findAll', () => {
+    const mockRows = [
+      {
+        id: 1,
+        created_at: new Date('2026-01-01T00:00:00Z'),
+        actor: 'user-123',
+        action: 'CREATE',
+        entity_type: 'roles',
+        entity_id: '42',
+        before_state: null,
+        after_state: { name: 'admin' },
+      }
+    ];
+
+    it('should return mapped rows with camelCase fields', async () => {
+      mockDb.executeWithErrorCount.mockResolvedValue(mockRows);
+
+      const result = await AuditModel.findAll();
+
+      expect(result).toEqual([{
+        id: 1,
+        createdAt: mockRows[0].created_at,
+        actor: 'user-123',
+        action: 'CREATE',
+        entityType: 'roles',
+        entityId: '42',
+        beforeState: null,
+        afterState: { name: 'admin' },
+      }]);
+    });
+
+    it('should return an empty array when there are no rows', async () => {
+      mockDb.executeWithErrorCount.mockResolvedValue([]);
+
+      const result = await AuditModel.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should pass filters to the query', async () => {
+      mockDb.executeWithErrorCount.mockResolvedValue([]);
+
+      await AuditModel.findAll({ from: '2026-01-01', to: '2026-12-31', actor: 'user-123', action: 'CREATE' });
+
+      expect(mockDb.executeWithErrorCount).toHaveBeenCalledWith(
+        expect.any(Function),
+        'findAuditLog'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
  - Adds `audit_log` DB table via Knex migration (timestamp, actor, action, entity_type, entity_id, before_state, after_state)
  - Adds `AuditMiddleware` that intercepts all IAM path mutations (roles, permissions, members, users, groups) and logs them asynchronously
  - Adds `GET /api/audit-log` endpoint with filtering by date range, actor, and action type

## Notes
  - The IAM path patterns (`/roles`, `/permissions`, `/members`, `/users`, `/groups`) are configured in `AuditMiddleware` but have no endpoints matching these paths exist in the swagger yet. 
  - IAM mutations currently happen inside `KeycloakService` (triggered by `POST /dfsps/{dfspId}/credentials` and `DELETE /dfsps/{dfspId}`), not through dedicated IAM HTTP endpoints. 
  - The middleware is intentionally scoped to future IAM endpoints as per the issue spec.
  - Actor is identified by Keycloak subject ID (`req.user.id`) for consistency.
  - `target` from the issue spec is represented as two fields (`entity_type` and `entity_id`) for more structured and queryable storage (e.g. `entity_type: "roles"`, `entity_id: "123"`).

  ## Test plan
  - [x] Unit tests: AuditMiddleware, AuditModel, AuditController (31 tests)
  - [x] Integration test: AuditService against real DB (9 tests)

  Closes mojaloop/project#4462


PS: If you do need me to include the endpoints in this PR, do let me know! 